### PR TITLE
Add Symbols mode + full palette matching + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# Wplace ELAUBros Overlay Loader
+
+Ein Tampermonkey‑Userscript, das Overlays für https://wplace.live direkt in die Kacheln rendert (wie „Overlay Pro“), inklusive UI, Transparenz‑Regler, Paletten‑Matching und drei Darstellungsmodi (Normal, Minify, Symbols).
+
+## Features
+
+- Overlay‑Quelle: Lädt mehrere Overlays aus einer JSON‑Datei (`overlays.json`).
+- UI im Spiel: Checkbox zum Ein-/Ausschalten je Overlay, Slider für Opazität, Modus‑Dropdown.
+- Paletten‑Matching: Mapped Overlay‑Farben auf die komplette Wplace‑Palette (Free + Paid) für exakte Farbvorschau.
+- Alpha hart: Härtet halbtransparente Pixel (klare Kanten statt weicher Ränder).
+- Modi (Dropdown „Modus“):
+  - Normal: Zeichnet die (palette‑gemappte) Vorlage 1:1 in die Tile.
+  - Minify: Zeichnet einen kleinen Farb‑Punkt im Zentrum jedes Overlay‑Pixels (intern 5× skaliert, dann herunterskaliert).
+  - Symbols: Zeichnet farbige 5×5‑Symbole je Palettenfarbe (intern 7× skaliert, dann herunterskaliert) – wie Overlay Pro.
+- Robust gegen Zoom/Pan: Es wird direkt in die geladenen Tile‑Bilder gerendert (nicht nur als DOM‑Overlay).
+
+## Installation (Tampermonkey)
+
+1) Tampermonkey im Browser installieren (Chrome, Edge, Firefox, Safari).
+2) Das Userscript `elaubros-userscript.js` in Tampermonkey hinzufügen (per „Create a new script“ und Inhalt einfügen) oder per „Raw“-Link importieren.
+3) Seite https://wplace.live öffnen/reloaden (ggf. hart neu laden: Ctrl/Cmd+Shift+R).
+
+## Konfiguration (overlays.json)
+
+Die Overlays werden aus einer JSON‑Datei geladen – standardmäßig aus diesem Repo (kann auf deinen Fork zeigen). Beispiel:
+
+```json
+{
+  "version": 1,
+  "overlays": [
+    {
+      "version": 1,
+      "name": "emily",
+      "imageUrl": "https://raw.githubusercontent.com/USER/REPO/BRANCH/images/emily.png",
+      "pixelUrl": "https://backend.wplace.live/s0/pixel/1088/678?x=254&y=673",
+      "offsetX": 0,
+      "offsetY": 0,
+      "opacity": 0.7
+    }
+  ]
+}
+```
+
+- `imageUrl`: Bild muss öffentlich erreichbar sein (z. B. GitHub Raw; private Repos funktionieren nicht ohne Auth). Discord‑CDN geht auch; Token‑Links können auslaufen.
+- `pixelUrl`: Anker‑Pixel auf dem Board. Aus `.../s0/pixel/<chunk1>/<chunk2>?x=<posX>&y=<posY>` werden Weltkoordinaten berechnet.
+- Offsets/Opazität: Feintuning je Overlay.
+
+## Bedienung im Spiel
+
+- Öffne das Overlay‑Panel oben rechts.
+- Checkbox je Overlay: Ein‑/Ausschalten.
+- Slider: Opazität (wirkt in allen Modi auf das Overlay/Symbol).
+- Palette‑Match: Ein/Aus – mapped Overlay‑Farben auf die Wplace‑Palette (empfohlen: Ein).
+- Alpha hart: Ein/Aus – harte Kanten statt Halbdurchsichtigkeiten.
+- Modus (Normal/Minify/Symbols):
+  - Normal: Volle Vorlage in die Tiles (1:1).
+  - Minify: Kleiner Punkt im Zentrum jedes Overlay‑Pixels.
+  - Symbols: Farbiges 5×5‑Symbol je Palettenfarbe.
+
+## Troubleshooting
+
+- „Ich sehe keine Overlays“: UI prüfen (Checkbox aktiv?), Bild‑URL erreichbar? Konsole: „overlay image loaded …“ sollte erscheinen.
+- „Hook greift nicht“: Script muss im Page‑Kontext laufen. In der Konsole sollten bei neuen Tiles „ELAUBros hook composing tile …“ Logs stehen. Bei Bedarf Injection Mode = page setzen und harten Reload durchführen.
+- „Minify/Symbols zeigen nichts Neues“: Tiles sind gecached. Kurz pan/zoom, oder Service Worker (Application → Service Workers) „Unregister/Update“ und dann neu laden.
+- „Farbabweichungen“: Palette‑Match einschalten (nutzt Free+Paid Palette). Falls exakt Free‑Only nötig, bitte Issue/PR erstellen (kann optional schaltbar gemacht werden).
+
+## Entwicklungsnotizen
+
+- Das Script nutzt Tampermonkey API (`GM_xmlhttpRequest`, `GM_addStyle`) und ersetzt Tile‑Responses über Hooks (`fetch`, zusätzlich `Image.src`).
+- Es läuft früh (`document-start`) im **Page‑Kontext** (nicht Content‑Sandbox), damit Tile‑Requests interceptet werden können.
+- Image‑Loading per GM_xhr → Data‑URL, um CORS‑Probleme zu vermeiden.
+
+## Lizenz und Danksagung
+
+- Teile der Paletten‑ und Symbol‑Daten sowie die Render‑Idee der Minify/Symbols‑Modi sind von „Wplace Overlay Pro“ (Autor: shinkonet) inspiriert bzw. adaptiert. Vielen Dank!
+- Dieses Userscript steht unter **GPLv3** (wie das Referenzprojekt). Bitte Lizenzhinweise beibehalten.

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Wplace ELAUBros Overlay Loader(Beta)
 // @namespace    https://github.com/Stegi96
-// @version      1.32.4
+// @version      1.32.5
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -18,7 +18,7 @@
 
 (function() {
     'use strict';
-    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.4' }); } catch {}
+    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.5' }); } catch {}
 
     const CONFIG_URL = "https://raw.githubusercontent.com/Stegi96/WPlaceUserscript/refs/heads/main/overlays.json";
     const TILE_SIZE = 1000; // wie Overlay Pro
@@ -766,25 +766,3 @@
     });
 
 })();
-    const WPLACE_PAID = [
-        [170,170,170],[165,14,30],[250,128,114],[228,92,26],[156,132,49],[197,173,49],[232,212,95],
-        [74,107,58],[90,148,74],[132,197,115],[15,121,159],[187,250,242],[125,199,255],[77,49,184],
-        [74,66,132],[122,113,196],[181,174,241],[155,82,73],[209,128,120],[250,182,164],[219,164,99],
-        [123,99,82],[156,132,107],[214,181,148],[209,128,81],[255,197,165],[109,100,63],[148,140,107],
-        [205,197,158],[51,57,65],[109,117,141],[179,185,209]
-    ];
-    const ALL_COLORS = [...WPLACE_FREE, ...WPLACE_PAID];
-    const colorIndexMap = new Map(ALL_COLORS.map((c,i)=>[c.join(','), i]));
-    function findColorIndexLUT(r,g,b){
-        let best=-1, bestD=Infinity;
-        for(let i=0;i<ALL_COLORS.length;i++){
-            const c=ALL_COLORS[i];
-            const d=colorDist2(r,g,b,c[0],c[1],c[2]);
-            if(d<bestD){bestD=d;best=i;}
-        }
-        return best<0?0:best;
-    }
-    const SYMBOL_W = 5;
-    const SYMBOL_H = 5;
-    const SYMBOL_TILES = new Uint32Array([4897444,4756004,15241774,11065002,15269550,33209205,15728622,15658734,33226431,33391295,32641727,15589098,11516906,9760338,15399560,4685802,15587182,29206876,3570904,15259182,29224831,21427311,22511061,15161013,4667844,11392452,11375466,6812424,5225454,29197179,18285009,31850982,19267878,16236308,33481548,22708917,14352822,7847326,7652956,22501038,28457653,9179234,30349539,4685269,18295249,26843769,24483191,5211003,14829567,17971345,28873275,4681156,21392581,7460636,23013877,29010254,18846257,21825364,29017787,4357252,23057550,26880179,5242308,15237450]);
-    const MINIFY_SCALE_SYMBOL = 7;

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name         Wplace ELAUBros Overlay Loader(Beta)
+// @name         Wplace ELAUBros Overlay Loader
 // @namespace    https://github.com/Stegi96
-// @version      1.32.6
+// @version      1.33
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -18,7 +18,7 @@
 
 (function() {
     'use strict';
-    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.6' }); } catch {}
+    try { console.log('[ELAUBros] userscript loaded', { version: '1.33' }); } catch {}
 
     const CONFIG_URL = "https://raw.githubusercontent.com/Stegi96/WPlaceUserscript/refs/heads/main/overlays.json";
     const TILE_SIZE = 1000; // wie Overlay Pro

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -38,8 +38,8 @@
     ];
 
     function colorDist2(r1,g1,b1, r2,g2,b2){const dr=r1-r2,dg=g1-g2,db=b1-b2;return dr*dr+dg*dg+db*db;}
-    function nearestPaletteColor(r,g,b){let best=WPLACE_FREE[0],bd=Infinity;for(const c of WPLACE_FREE){const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;best=c;}}return best;}
-    function nearestPaletteIndex(r,g,b){let bestIdx=0,bd=Infinity;for(let i=0;i<WPLACE_FREE.length;i++){const c=WPLACE_FREE[i];const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;bestIdx=i;}}return bestIdx;}
+    function nearestPaletteColor(r,g,b){let best=ALL_COLORS[0],bd=Infinity;for(const c of ALL_COLORS){const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;best=c;}}return best;}
+    function nearestPaletteIndex(r,g,b){let bestIdx=0,bd=Infinity;for(let i=0;i<ALL_COLORS.length;i++){const c=ALL_COLORS[i];const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;bestIdx=i;}}return bestIdx;}
 
     // Full palette + symbol tiles (must be defined before use)
     const WPLACE_PAID = [

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Wplace ELAUBros Overlay Loader(Beta)
 // @namespace    https://github.com/Stegi96
-// @version      1.32.2
+// @version      1.32.3
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -18,6 +18,7 @@
 
 (function() {
     'use strict';
+    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.2' }); } catch {}
 
     const CONFIG_URL = "https://raw.githubusercontent.com/Stegi96/WPlaceUserscript/refs/heads/main/overlays.json";
     const TILE_SIZE = 1000; // wie Overlay Pro

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Wplace ELAUBros Overlay Loader(Beta)
 // @namespace    https://github.com/Stegi96
-// @version      1.32.3
+// @version      1.32.4
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -18,7 +18,7 @@
 
 (function() {
     'use strict';
-    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.2' }); } catch {}
+    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.4' }); } catch {}
 
     const CONFIG_URL = "https://raw.githubusercontent.com/Stegi96/WPlaceUserscript/refs/heads/main/overlays.json";
     const TILE_SIZE = 1000; // wie Overlay Pro
@@ -40,6 +40,9 @@
     function colorDist2(r1,g1,b1, r2,g2,b2){const dr=r1-r2,dg=g1-g2,db=b1-b2;return dr*dr+dg*dg+db*db;}
     function nearestPaletteColor(r,g,b){let best=WPLACE_FREE[0],bd=Infinity;for(const c of WPLACE_FREE){const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;best=c;}}return best;}
     function nearestPaletteIndex(r,g,b){let bestIdx=0,bd=Infinity;for(let i=0;i<WPLACE_FREE.length;i++){const c=WPLACE_FREE[i];const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;bestIdx=i;}}return bestIdx;}
+
+    // Ergänze Paid-Palette und Symboldaten VOR Nutzung (TDZ vermeiden)
+    // (verschoben nach oben)
 
     // Symbolmuster (Offsets relativ zur Zellmitte) für "Symbols"-Modus
     const SYMBOL_PATTERNS = [

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Wplace ELAUBros Overlay Loader(Beta)
 // @namespace    https://github.com/Stegi96
-// @version      1.32.1
+// @version      1.32.2
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -438,7 +438,7 @@
                         const sw = srcCanvas.width, sh = srcCanvas.height;
                         const imgd = sctx.getImageData(0, 0, sw, sh);
                         const data = imgd.data; const rowW = imgd.width;
-                        const centerX = (settings.renderMode === 'symbols') ? (MIN_SCALE - SYMBOL_W >> 1) : Math.floor(MIN_SCALE / 2);
+                        const centerX = (settings.renderMode === 'symbols') ? ((MIN_SCALE - SYMBOL_W) >> 1) : Math.floor(MIN_SCALE / 2);
                         const centerY = centerX;
                         let drawn = 0;
                         for (let y=0; y<sh; y++) {
@@ -495,7 +495,7 @@
                         ctx.globalAlpha = 1;
                     }
                 }
-                if (settings.renderMode === 'minify' && scaledCanvas) {
+                if ((settings.renderMode === 'minify' || settings.renderMode === 'symbols') && scaledCanvas) {
                     // Ersetze die Tile durch die hochskalierte Version (Seite skaliert beim Rendern herunter)
                     // Exportiere direkt den Inhalt der skalierten Canvas
                     return await new Promise((resolve, reject) => {

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name         Wplace ELAUBros Overlay Loader
+// @name         Wplace ELAUBros Overlay Loader(Beta)
 // @namespace    https://github.com/Stegi96
-// @version      1.31
+// @version      1.32.1
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -13,6 +13,7 @@
 // @connect      media.discordapp.net
 // @run-at       document-start
 // @inject-into  page
+// @license      GPLv3
 // ==/UserScript==
 
 (function() {
@@ -24,6 +25,7 @@
     const settings = { paletteMatch: true, alphaHarden: true, renderMode: 'normal' };
 
     // Wplace-Palette (Free)
+    // Palette and symbol data adapted from Wplace Overlay Pro (GPLv3)
     const WPLACE_FREE = [
         [0,0,0],[60,60,60],[120,120,120],[210,210,210],[255,255,255],
         [96,0,24],[237,28,36],[255,127,39],[246,170,9],[249,221,59],[255,250,188],
@@ -36,6 +38,27 @@
 
     function colorDist2(r1,g1,b1, r2,g2,b2){const dr=r1-r2,dg=g1-g2,db=b1-b2;return dr*dr+dg*dg+db*db;}
     function nearestPaletteColor(r,g,b){let best=WPLACE_FREE[0],bd=Infinity;for(const c of WPLACE_FREE){const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;best=c;}}return best;}
+    function nearestPaletteIndex(r,g,b){let bestIdx=0,bd=Infinity;for(let i=0;i<WPLACE_FREE.length;i++){const c=WPLACE_FREE[i];const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;bestIdx=i;}}return bestIdx;}
+
+    // Symbolmuster (Offsets relativ zur Zellmitte) für "Symbols"-Modus
+    const SYMBOL_PATTERNS = [
+        // Plus
+        [[0,0],[-1,0],[1,0],[0,-1],[0,1]],
+        // X
+        [[0,0],[-1,-1],[1,1],[-1,1],[1,-1]],
+        // Quadrat (klein)
+        [[0,0],[-1,0],[1,0],[0,-1],[0,1],[-1,-1],[1,1],[1,-1],[-1,1]],
+        // T oben
+        [[0,0],[-1,0],[1,0],[0,1]],
+        // L
+        [[0,0],[1,0],[0,1]],
+        // I vertikal
+        [[0,-1],[0,0],[0,1]],
+        // I horizontal
+        [[-1,0],[0,0],[1,0]],
+        // Punkt
+        [[0,0]]
+    ];
 
     // GM fetch helpers to avoid CORS tainting
     function gmFetchBlob(url){return new Promise((resolve,reject)=>{try{GM_xmlhttpRequest({method:'GET',url,responseType:'blob',onload:(res)=>{if(res.status>=200&&res.status<300&&res.response)resolve(res.response);else reject(new Error('GM_xhr '+res.status));},onerror:()=>reject(new Error('GM_xhr network error')),ontimeout:()=>reject(new Error('GM_xhr timeout'))});}catch(e){reject(e);}})}
@@ -382,10 +405,10 @@
                 // Zeichne Originaltile
                 ctx.drawImage(tileImg, 0, 0, TILE_SIZE, TILE_SIZE);
 
-                // Für Minify: skaliere die Tile hoch (z.B. 5x) und setze Dots im Zellzentrum
-                const MIN_SCALE = 5; // wie Overlay Pro (Zellgröße)
+                // Für Minify/Symbols: skaliere die Tile hoch (Pro-Pipeline)
+                const MIN_SCALE = (settings.renderMode === 'symbols') ? MINIFY_SCALE_SYMBOL : 5;
                 let scaledCanvas = null, scaledCtx = null;
-                if (settings.renderMode === 'minify') {
+                if (settings.renderMode === 'minify' || settings.renderMode === 'symbols') {
                     const tileW = TILE_SIZE * MIN_SCALE;
                     const tileH = TILE_SIZE * MIN_SCALE;
                     scaledCanvas = document.createElement('canvas');
@@ -407,7 +430,7 @@
                         continue; // komplett außerhalb dieses Tiles
                     }
                     const opacity = Number(ov.opacity ?? 0.5);
-                    if (settings.renderMode === 'minify' && scaledCtx) {
+                    if ((settings.renderMode === 'minify' || settings.renderMode === 'symbols') && scaledCtx) {
                         // Quelle: quantisierte oder Original-Overlay-Canvas
                         const srcCanvas = (settings.paletteMatch && ov.processedCanvas) ? ov.processedCanvas : (() => {
                             const c=document.createElement('canvas'); c.width=ov.img.naturalWidth; c.height=ov.img.naturalHeight; const cx=c.getContext('2d',{willReadFrequently:true}); cx.imageSmoothingEnabled=false; cx.drawImage(ov.img,0,0); return c; })();
@@ -415,7 +438,8 @@
                         const sw = srcCanvas.width, sh = srcCanvas.height;
                         const imgd = sctx.getImageData(0, 0, sw, sh);
                         const data = imgd.data; const rowW = imgd.width;
-                        const center = Math.floor(MIN_SCALE / 2);
+                        const centerX = (settings.renderMode === 'symbols') ? (MIN_SCALE - SYMBOL_W >> 1) : Math.floor(MIN_SCALE / 2);
+                        const centerY = centerX;
                         let drawn = 0;
                         for (let y=0; y<sh; y++) {
                             const ty = drawY + y;
@@ -426,12 +450,39 @@
                                 const idx = (y*rowW + x) * 4;
                                 const a = data[idx+3]; if (a === 0) continue;
                                 const r=data[idx], g=data[idx+1], b=data[idx+2];
-                                scaledCtx.globalAlpha = (a/255) * opacity;
-                                scaledCtx.fillStyle = `rgb(${r},${g},${b})`;
-                                const baseX = tx * MIN_SCALE + center;
-                                const baseY = ty * MIN_SCALE + center;
-                                // Punkt im Zentrum (1x1 Pixel im hochskalierten Raum)
-                                scaledCtx.fillRect(baseX, baseY, 1, 1);
+                                const baseX = tx * MIN_SCALE;
+                                const baseY = ty * MIN_SCALE;
+                                if (settings.renderMode === 'symbols') {
+                                    // Exakte Symbols-Logik wie Overlay Pro
+                                    // Bestimme Farbindex (perfekt, wenn bereits paletteMatch erfolgte)
+                                    const colorKey = `${r},${g},${b}`;
+                                    const isPerfect = settings.paletteMatch;
+                                    const colorIndex = isPerfect && colorIndexMap.has(colorKey) ? colorIndexMap.get(colorKey) : findColorIndexLUT(r,g,b);
+                                    if (colorIndex >= 0 && colorIndex < SYMBOL_TILES.length) {
+                                        const symbol = SYMBOL_TILES[colorIndex];
+                                        const pal = ALL_COLORS[colorIndex];
+                                        scaledCtx.globalAlpha = (a/255) * opacity;
+                                        scaledCtx.fillStyle = `rgb(${pal[0]},${pal[1]},${pal[2]})`;
+                                        for (let sy=0; sy<SYMBOL_H; sy++) {
+                                            for (let sx=0; sx<SYMBOL_W; sx++) {
+                                                const bitIdx = sy*SYMBOL_W + sx;
+                                                if ((symbol >>> bitIdx) & 1) {
+                                                    const outX = baseX + sx + centerX;
+                                                    const outY = baseY + sy + centerY;
+                                                    scaledCtx.fillRect(outX, outY, 1, 1);
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    // Minify: farbiger Punkt im Zentrum
+                                    const c = settings.paletteMatch ? nearestPaletteColor(r,g,b) : [r,g,b];
+                                    scaledCtx.globalAlpha = (a/255) * opacity;
+                                    scaledCtx.fillStyle = `rgb(${c[0]},${c[1]},${c[2]})`;
+                                    const dotX = baseX + Math.floor(MIN_SCALE/2);
+                                    const dotY = baseY + Math.floor(MIN_SCALE/2);
+                                    scaledCtx.fillRect(dotX, dotY, 1, 1);
+                                }
                                 drawn++;
                             }
                         }
@@ -520,6 +571,7 @@
       <select id="elaubros-mode">
         <option value="normal" selected>Normal</option>
         <option value="minify">Minify</option>
+        <option value="symbols">Symbols</option>
       </select>
     </label>
     `;
@@ -599,6 +651,7 @@
         // Tile-basierter Minify; DOM-Layer nicht nutzen
         stopMinifyLoop();
     });
+    // no checkbox for symbols; use dropdown mode
 
     // JSON laden
     GM_xmlhttpRequest({
@@ -709,3 +762,25 @@
     });
 
 })();
+    const WPLACE_PAID = [
+        [170,170,170],[165,14,30],[250,128,114],[228,92,26],[156,132,49],[197,173,49],[232,212,95],
+        [74,107,58],[90,148,74],[132,197,115],[15,121,159],[187,250,242],[125,199,255],[77,49,184],
+        [74,66,132],[122,113,196],[181,174,241],[155,82,73],[209,128,120],[250,182,164],[219,164,99],
+        [123,99,82],[156,132,107],[214,181,148],[209,128,81],[255,197,165],[109,100,63],[148,140,107],
+        [205,197,158],[51,57,65],[109,117,141],[179,185,209]
+    ];
+    const ALL_COLORS = [...WPLACE_FREE, ...WPLACE_PAID];
+    const colorIndexMap = new Map(ALL_COLORS.map((c,i)=>[c.join(','), i]));
+    function findColorIndexLUT(r,g,b){
+        let best=-1, bestD=Infinity;
+        for(let i=0;i<ALL_COLORS.length;i++){
+            const c=ALL_COLORS[i];
+            const d=colorDist2(r,g,b,c[0],c[1],c[2]);
+            if(d<bestD){bestD=d;best=i;}
+        }
+        return best<0?0:best;
+    }
+    const SYMBOL_W = 5;
+    const SYMBOL_H = 5;
+    const SYMBOL_TILES = new Uint32Array([4897444,4756004,15241774,11065002,15269550,33209205,15728622,15658734,33226431,33391295,32641727,15589098,11516906,9760338,15399560,4685802,15587182,29206876,3570904,15259182,29224831,21427311,22511061,15161013,4667844,11392452,11375466,6812424,5225454,29197179,18285009,31850982,19267878,16236308,33481548,22708917,14352822,7847326,7652956,22501038,28457653,9179234,30349539,4685269,18295249,26843769,24483191,5211003,14829567,17971345,28873275,4681156,21392581,7460636,23013877,29010254,18846257,21825364,29017787,4357252,23057550,26880179,5242308,15237450]);
+    const MINIFY_SCALE_SYMBOL = 7;

--- a/elaubros-userscript.js
+++ b/elaubros-userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Wplace ELAUBros Overlay Loader(Beta)
 // @namespace    https://github.com/Stegi96
-// @version      1.32.5
+// @version      1.32.6
 // @description  Lädt alle Overlays aus einer JSON-Datei für Wplace.live, positioniert nach Pixel-URL, mit Menü und Transparenz-Slider, korrekt auf dem Spielfeld
 // @author       ELAUBros
 // @match        https://wplace.live/*
@@ -18,7 +18,7 @@
 
 (function() {
     'use strict';
-    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.5' }); } catch {}
+    try { console.log('[ELAUBros] userscript loaded', { version: '1.32.6' }); } catch {}
 
     const CONFIG_URL = "https://raw.githubusercontent.com/Stegi96/WPlaceUserscript/refs/heads/main/overlays.json";
     const TILE_SIZE = 1000; // wie Overlay Pro
@@ -40,6 +40,30 @@
     function colorDist2(r1,g1,b1, r2,g2,b2){const dr=r1-r2,dg=g1-g2,db=b1-b2;return dr*dr+dg*dg+db*db;}
     function nearestPaletteColor(r,g,b){let best=WPLACE_FREE[0],bd=Infinity;for(const c of WPLACE_FREE){const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;best=c;}}return best;}
     function nearestPaletteIndex(r,g,b){let bestIdx=0,bd=Infinity;for(let i=0;i<WPLACE_FREE.length;i++){const c=WPLACE_FREE[i];const d=colorDist2(r,g,b,c[0],c[1],c[2]);if(d<bd){bd=d;bestIdx=i;}}return bestIdx;}
+
+    // Full palette + symbol tiles (must be defined before use)
+    const WPLACE_PAID = [
+        [170,170,170],[165,14,30],[250,128,114],[228,92,26],[156,132,49],[197,173,49],[232,212,95],
+        [74,107,58],[90,148,74],[132,197,115],[15,121,159],[187,250,242],[125,199,255],[77,49,184],
+        [74,66,132],[122,113,196],[181,174,241],[155,82,73],[209,128,120],[250,182,164],[219,164,99],
+        [123,99,82],[156,132,107],[214,181,148],[209,128,81],[255,197,165],[109,100,63],[148,140,107],
+        [205,197,158],[51,57,65],[109,117,141],[179,185,209]
+    ];
+    const ALL_COLORS = [...WPLACE_FREE, ...WPLACE_PAID];
+    const colorIndexMap = new Map(ALL_COLORS.map((c,i)=>[c.join(','), i]));
+    function findColorIndexLUT(r,g,b){
+        let best=-1, bestD=Infinity;
+        for(let i=0;i<ALL_COLORS.length;i++){
+            const c=ALL_COLORS[i];
+            const d=colorDist2(r,g,b,c[0],c[1],c[2]);
+            if(d<bestD){bestD=d;best=i;}
+        }
+        return best<0?0:best;
+    }
+    const SYMBOL_W = 5;
+    const SYMBOL_H = 5;
+    const SYMBOL_TILES = new Uint32Array([4897444,4756004,15241774,11065002,15269550,33209205,15728622,15658734,33226431,33391295,32641727,15589098,11516906,9760338,15399560,4685802,15587182,29206876,3570904,15259182,29224831,21427311,22511061,15161013,4667844,11392452,11375466,6812424,5225454,29197179,18285009,31850982,19267878,16236308,33481548,22708917,14352822,7847326,7652956,22501038,28457653,9179234,30349539,4685269,18295249,26843769,24483191,5211003,14829567,17971345,28873275,4681156,21392581,7460636,23013877,29010254,18846257,21825364,29017787,4357252,23057550,26880179,5242308,15237450]);
+    const MINIFY_SCALE_SYMBOL = 7;
 
     // Ergänze Paid-Palette und Symboldaten VOR Nutzung (TDZ vermeiden)
     // (verschoben nach oben)


### PR DESCRIPTION
- Neuer Modus „Symbols“: Rendert farbige Symbole je Palettenfarbe.

- Paletten‑Matching: Quantisierung jetzt auf komplette Wplace‑Palette (Free + Paid) für Normal und Minify.

- README ergänzt: Installation (Tampermonkey), Modi‑Erklärung, Troubleshooting, Lizenz/Attribution.